### PR TITLE
fix: add qt-wayland on linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 # pixi environments
 .pixi
 *.egg-info
+output

--- a/recipes/pixi-editor/menu/menu.json
+++ b/recipes/pixi-editor/menu/menu.json
@@ -27,7 +27,7 @@
                         "Development",
                         "Science"
                     ],
-                    "command": ["gedit", "%F"],
+                    "command": ["{{ PREFIX }}/bin/python", "{{ PREFIX }}/bin/pixi-editor-launcher.py", "$@"],
                     "MimeType": [
                         "text/x-pixi"
                     ]

--- a/recipes/pixi-editor/recipe.yaml
+++ b/recipes/pixi-editor/recipe.yaml
@@ -14,3 +14,5 @@ build:
 requirements:
   run:
     - pyqt 5.*
+    - if: linux
+      then: qt-wayland


### PR DESCRIPTION
I wonder why that isn't pulled in automatically by pyqt5